### PR TITLE
Add simple browser-based ChatGPT client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# ChatGPT API in the Browser
+
+This project provides a simple web interface for talking to OpenAI's ChatGPT models using your own API key. The page stores your key and conversation history in your browser's local storage.
+
+## Usage
+
+1. Open `index.html` in a modern web browser.
+2. Enter your OpenAI API key and click **Save**.
+3. Choose a model and start chatting.
+4. Your conversation is stored locally and can be cleared or downloaded as JSON.
+
+**Security note:** your API key is stored in plain text in your browser's storage. Do not use this on shared or untrusted computers.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>ChatGPT API in the Browser</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 800px; margin: auto; padding: 1em; }
+    #chat { border: 1px solid #ccc; padding: 1em; height: 400px; overflow-y: auto; margin-bottom: 1em; }
+    .message { margin-bottom: 1em; }
+    .user { color: blue; }
+    .assistant { color: green; }
+    textarea { width: 100%; }
+  </style>
+</head>
+<body>
+  <h1>ChatGPT API in the Browser</h1>
+  <div>
+    <label>API Key: <input type="password" id="apiKey"></label>
+    <button id="saveKey">Save</button>
+  </div>
+  <div>
+    <label>Model:
+      <select id="model">
+        <option value="gpt-4-turbo">gpt-4-turbo</option>
+        <option value="gpt-3.5-turbo">gpt-3.5-turbo</option>
+      </select>
+    </label>
+  </div>
+  <div id="chat"></div>
+  <textarea id="userInput" rows="3" placeholder="Type your message..."></textarea>
+  <div>
+    <button id="send">Send</button>
+    <button id="clear">Clear</button>
+    <button id="download">Download Conversation</button>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,98 @@
+function loadSettings() {
+  const key = localStorage.getItem('apiKey');
+  if (key) document.getElementById('apiKey').value = key;
+  const model = localStorage.getItem('model');
+  if (model) document.getElementById('model').value = model;
+}
+
+function loadConversation() {
+  const conv = localStorage.getItem('conversation');
+  return conv ? JSON.parse(conv) : [];
+}
+
+function saveConversation(conv) {
+  localStorage.setItem('conversation', JSON.stringify(conv));
+}
+
+function renderConversation() {
+  const chat = document.getElementById('chat');
+  chat.innerHTML = '';
+  const conv = loadConversation();
+  conv.forEach(msg => {
+    const div = document.createElement('div');
+    div.className = 'message ' + msg.role;
+    div.textContent = msg.role + ': ' + msg.content;
+    chat.appendChild(div);
+  });
+  chat.scrollTop = chat.scrollHeight;
+}
+
+async function sendMessage() {
+  const apiKey = document.getElementById('apiKey').value.trim();
+  if (!apiKey) {
+    alert('Please set your API key.');
+    return;
+  }
+  const model = document.getElementById('model').value;
+  localStorage.setItem('apiKey', apiKey);
+  localStorage.setItem('model', model);
+
+  const conv = loadConversation();
+  const content = document.getElementById('userInput').value.trim();
+  if (!content) return;
+  conv.push({ role: 'user', content });
+  document.getElementById('userInput').value = '';
+  renderConversation();
+  saveConversation(conv);
+
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer ' + apiKey
+    },
+    body: JSON.stringify({
+      model,
+      messages: conv
+    })
+  });
+  const data = await res.json();
+  if (data.error) {
+    alert(data.error.message);
+    return;
+  }
+  const reply = data.choices[0].message.content;
+  conv.push({ role: 'assistant', content: reply });
+  saveConversation(conv);
+  renderConversation();
+}
+
+function clearConversation() {
+  localStorage.removeItem('conversation');
+  renderConversation();
+}
+
+function downloadConversation() {
+  const conv = loadConversation();
+  const blob = new Blob([JSON.stringify(conv, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'conversation.json';
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+document.getElementById('saveKey').addEventListener('click', () => {
+  const key = document.getElementById('apiKey').value.trim();
+  localStorage.setItem('apiKey', key);
+});
+
+document.getElementById('send').addEventListener('click', sendMessage);
+
+document.getElementById('clear').addEventListener('click', clearConversation);
+
+document.getElementById('download').addEventListener('click', downloadConversation);
+
+loadSettings();
+renderConversation();


### PR DESCRIPTION
## Summary
- provide a minimal web UI that stores the API key and conversation in browser storage
- allow the user to select model, send prompts and download the chat log
- document how to use the browser interface

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68410c573b10832f987cf6f5700d543c